### PR TITLE
Adding support for id's from Visualforce URL's /apex/SomePage?id=THEID

### DIFF
--- a/background.html
+++ b/background.html
@@ -9,7 +9,7 @@
 		<script>
 
                 BASIC_RE = /https\:\/\/.*\.salesforce\.com\/(\w{15})/ ;
-                VFORCE_RE = /https\:\/\/.*\.salesforce\.com\/apex/.*id=(\w{15}).*/ ;
+                VFORCE_RE = /https\:\/\/.*\.salesforce\.com\/apex\/.*id=(\w{15}).*/ ;
 
 		// Called when the url of a tab changes.
 		function checkForValidUrl(tabId, changeInfo, tab) {


### PR DESCRIPTION
This is a great chrome extension! 
I just added a second Regex to also match Id's in /apex/ URLs, since I also use and look to those a bunch, as well.  Happy for you to pull, or not if you'd like to keep the extension simple.
