### PR TITLE
New version

### DIFF
--- a/background.html
+++ b/background.html
@@ -23,7 +23,7 @@
 		function checkForValidUrl(tabId, changeInfo, tab) {
 			// If it's a salesforce database URL and contains an id
 			if ((tab.url.indexOf('salesforce') > -1) && 
-                             ((tab.url.match(ID_RE[0]) != null) || (tab.url.match(ID_RE[1]) != null))) {
+                             ((tab.url.match(ID_RE[1]) != null) || (tab.url.match(ID_RE[2]) != null))) {
 				// ... show the page action.
 				chrome.pageAction.show(tabId);
 				chrome.pageAction.setIcon({path: "clipper.png", tabId: tab.id});


### PR DESCRIPTION
Looks like you had a typo on your line 12, with two open ( ( in the LINK regex and only one ), causing a syntax error.

While I was checking that out, though, I noticed that the code kept throwing uncaught TypeErrors when then wasn't a match - so rather than 'doing nothing' silently when there wasn't a match, it was raising an exception.  In this commit refactored it so that it actively checks for a match, and combined the three similar functions into one common routine.
